### PR TITLE
Remove usages of import map

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,4 @@
 {
-  "importMap": "import_map.json",
-
   "lint": {
     "files": { "exclude": ["npm"] },
     "rules": {
@@ -10,7 +8,6 @@
         "explicit-function-return-type",
         "explicit-module-boundary-types",
         "eqeqeq",
-        "no-external-import",
         "ban-untagged-todo"
       ]
     }

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,3 @@
+export * from "https://deno.land/std@0.170.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.170.0/datetime/mod.ts";
+export * from "https://deno.land/std@0.170.0/http/mod.ts";

--- a/import_map.json
+++ b/import_map.json
@@ -1,8 +1,0 @@
-{
-  "imports": {
-    "webuntis/requests": "./src/webuntis/requests/mod.ts",
-    "webuntis/resources": "./src/webuntis/resources/mod.ts",
-    "lib/": "./lib/",
-    "std/": "https://deno.land/std@0.170.0/"
-  }
-}

--- a/lib/datetime/Time.ts
+++ b/lib/datetime/Time.ts
@@ -1,5 +1,5 @@
 import { TimeUnits } from "./TimeUnits.ts";
-import { assert } from "std/testing/asserts.ts";
+import { assert } from "../../deps.ts";
 
 /** Helper for comparing the start and end times of lessons. By no means a replacement for {@link Date}. */
 export class Time {

--- a/lib/datetime/Time_test.ts
+++ b/lib/datetime/Time_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "std/testing/asserts.ts";
+import { assert } from "../../deps.ts";
 import { Time } from "./mod.ts";
 
 Deno.test("Time.selectEarlier() - should work with different hours", () => {

--- a/lib/datetime/untis.ts
+++ b/lib/datetime/untis.ts
@@ -1,4 +1,4 @@
-import { format, parse } from "std/datetime/mod.ts";
+import { format, parse } from "../../deps.ts";
 import { Time } from "./Time.ts";
 
 /** Parse a date from the WebUntis API into a JS Date object using local time. */

--- a/lib/jsonrpc/RpcClient.ts
+++ b/lib/jsonrpc/RpcClient.ts
@@ -1,4 +1,4 @@
-import { getSetCookies } from "std/http/mod.ts";
+import { getSetCookies } from "../../deps.ts";
 import { log } from "./requestLogger.ts";
 
 type RpcRequest = {

--- a/mod.ts
+++ b/mod.ts
@@ -3,7 +3,7 @@ export {
   type requestLogger,
   RpcError,
   setRequestLogger,
-} from "lib/jsonrpc/mod.ts";
+} from "./lib/jsonrpc/mod.ts";
 export * from "./src/wrappers/mod.ts";
 export * from "./src/searchSchools.ts";
 export * from "./src/UntisClient.ts";

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -17,7 +17,8 @@ await build({
 
   // Needed for fetch() and other modern APIs
   compilerOptions: {
-    lib: ["dom", "dom.iterable"],
+    target: "ES2021",
+    lib: ["esnext", "dom", "dom.iterable"],
   },
 
   // Technically not needed
@@ -40,6 +41,9 @@ await build({
     },
     engines: {
       node: ">=18",
+    },
+    devDependencies: {
+      "@types/node": "^17",
     },
   },
 });

--- a/src/UntisClient.ts
+++ b/src/UntisClient.ts
@@ -1,7 +1,7 @@
-import { RpcClient, RpcError } from "lib/jsonrpc/mod.ts";
-import { formatUntisDate } from "lib/datetime/untis.ts";
-import * as requests from "webuntis/requests";
-import { ElementType } from "webuntis/resources";
+import { RpcClient, RpcError } from "../lib/jsonrpc/mod.ts";
+import { formatUntisDate } from "../lib/datetime/untis.ts";
+import * as requests from "./webuntis/requests/mod.ts";
+import { ElementType } from "./webuntis/resources/mod.ts";
 import {
   Class,
   Holiday,

--- a/src/searchSchools.ts
+++ b/src/searchSchools.ts
@@ -1,5 +1,5 @@
-import { RpcClient, RpcError } from "lib/jsonrpc/mod.ts";
-import { ErrorCode, searchSchool } from "webuntis/requests";
+import { RpcClient, RpcError } from "../lib/jsonrpc/mod.ts";
+import { ErrorCode, searchSchool } from "./webuntis/requests/mod.ts";
 import { School } from "./wrappers/mod.ts";
 
 const rpcClient = new RpcClient("https://mobile.webuntis.com/ms/schoolquery2");

--- a/src/webuntis/requests/authenticate.ts
+++ b/src/webuntis/requests/authenticate.ts
@@ -1,4 +1,4 @@
-import { ElementType } from "webuntis/resources";
+import { ElementType } from "../resources/mod.ts";
 
 export const method = "authenticate";
 

--- a/src/webuntis/requests/getClasses.ts
+++ b/src/webuntis/requests/getClasses.ts
@@ -1,4 +1,4 @@
-import { schoolClass } from "webuntis/resources";
+import { schoolClass } from "../resources/mod.ts";
 
 export const method = "getKlassen";
 

--- a/src/webuntis/requests/getCurrentSchoolyear.ts
+++ b/src/webuntis/requests/getCurrentSchoolyear.ts
@@ -1,4 +1,4 @@
-import { schoolyear } from "webuntis/resources";
+import { schoolyear } from "../resources/mod.ts";
 
 export const method = "getCurrentSchoolyear";
 

--- a/src/webuntis/requests/getHolidays.ts
+++ b/src/webuntis/requests/getHolidays.ts
@@ -1,4 +1,4 @@
-import { holiday } from "webuntis/resources";
+import { holiday } from "../resources/mod.ts";
 
 export const method = "getHolidays";
 

--- a/src/webuntis/requests/getRooms.ts
+++ b/src/webuntis/requests/getRooms.ts
@@ -1,4 +1,4 @@
-import { room } from "webuntis/resources";
+import { room } from "../resources/mod.ts";
 
 export const method = "getRooms";
 

--- a/src/webuntis/requests/getSchoolyears.ts
+++ b/src/webuntis/requests/getSchoolyears.ts
@@ -1,4 +1,4 @@
-import { schoolyear } from "webuntis/resources";
+import { schoolyear } from "../resources/mod.ts";
 
 export const method = "getSchoolyears";
 

--- a/src/webuntis/requests/getStudents.ts
+++ b/src/webuntis/requests/getStudents.ts
@@ -1,4 +1,4 @@
-import { student } from "webuntis/resources";
+import { student } from "../resources/mod.ts";
 
 export const method = "getStudents";
 

--- a/src/webuntis/requests/getSubjects.ts
+++ b/src/webuntis/requests/getSubjects.ts
@@ -1,4 +1,4 @@
-import { subject } from "webuntis/resources";
+import { subject } from "../resources/mod.ts";
 
 export const method = "getSubjects";
 

--- a/src/webuntis/requests/getTeachers.ts
+++ b/src/webuntis/requests/getTeachers.ts
@@ -1,4 +1,4 @@
-import { teacher } from "webuntis/resources";
+import { teacher } from "../resources/mod.ts";
 
 export const method = "getTeachers";
 

--- a/src/webuntis/requests/getTimetable.ts
+++ b/src/webuntis/requests/getTimetable.ts
@@ -1,4 +1,4 @@
-import { ElementType, lesson } from "webuntis/resources";
+import { ElementType, lesson } from "../resources/mod.ts";
 
 export const method = "getTimetable";
 

--- a/src/webuntis/requests/searchSchool.ts
+++ b/src/webuntis/requests/searchSchool.ts
@@ -1,4 +1,4 @@
-import { school } from "webuntis/resources";
+import { school } from "../resources/mod.ts";
 
 export const method = "searchSchool";
 

--- a/src/wrappers/Holiday.ts
+++ b/src/wrappers/Holiday.ts
@@ -1,5 +1,5 @@
-import { holiday } from "webuntis/resources";
-import { parseUntisDate } from "lib/datetime/untis.ts";
+import { parseUntisDate } from "../../lib/datetime/untis.ts";
+import { holiday } from "../webuntis/resources/mod.ts";
 
 /** Wrapper around the holiday object. */
 export class Holiday {

--- a/src/wrappers/Lesson.ts
+++ b/src/wrappers/Lesson.ts
@@ -1,5 +1,9 @@
-import { parseUntisDate, parseUntisTime, Time } from "lib/datetime/mod.ts";
-import { lesson } from "webuntis/resources";
+import {
+  parseUntisDate,
+  parseUntisTime,
+  Time,
+} from "../../lib/datetime/mod.ts";
+import { lesson } from "../webuntis/resources/mod.ts";
 import { LessonElementCollection } from "./LessonElementCollection.ts";
 import { Schedule } from "./Schedule.ts";
 

--- a/src/wrappers/LessonElement.ts
+++ b/src/wrappers/LessonElement.ts
@@ -1,4 +1,4 @@
-import { lessonElement } from "webuntis/resources";
+import { lessonElement } from "../webuntis/resources/mod.ts";
 
 /** Wrapper around an element included in a {@link Lesson}. */
 export class LessonElement {

--- a/src/wrappers/LessonElementCollection.ts
+++ b/src/wrappers/LessonElementCollection.ts
@@ -1,4 +1,4 @@
-import { lesson } from "webuntis/resources";
+import { lesson } from "../webuntis/resources/mod.ts";
 import { LessonElement } from "./LessonElement.ts";
 
 /** Represents a collection of elements included in a lesson. */

--- a/src/wrappers/Schedule.ts
+++ b/src/wrappers/Schedule.ts
@@ -1,4 +1,4 @@
-import { Time } from "lib/datetime/mod.ts";
+import { Time } from "../../lib/datetime/mod.ts";
 import { Lesson } from "./Lesson.ts";
 
 /**

--- a/src/wrappers/ScheduleCollection_test.ts
+++ b/src/wrappers/ScheduleCollection_test.ts
@@ -1,5 +1,5 @@
-import { assert } from "std/testing/asserts.ts";
-import { Time } from "lib/datetime/mod.ts";
+import { assert } from "../../deps.ts";
+import { Time } from "../../lib/datetime/mod.ts";
 import {
   Lesson,
   LessonElement,

--- a/src/wrappers/School.ts
+++ b/src/wrappers/School.ts
@@ -1,4 +1,4 @@
-import { school } from "webuntis/resources";
+import { school } from "../webuntis/resources/mod.ts";
 import { UntisClient } from "../UntisClient.ts";
 
 /** Wrapper around the school object. */

--- a/src/wrappers/Schoolyear.ts
+++ b/src/wrappers/Schoolyear.ts
@@ -1,5 +1,5 @@
-import { schoolyear } from "webuntis/resources";
-import { parseUntisDate } from "lib/datetime/mod.ts";
+import { schoolyear } from "../webuntis/resources/mod.ts";
+import { parseUntisDate } from "../../lib/datetime/mod.ts";
 
 /** Wrapper around the schoolyear object. */
 export class Schoolyear {

--- a/src/wrappers/mod.ts
+++ b/src/wrappers/mod.ts
@@ -5,7 +5,7 @@ export type {
   student as Student,
   subject as Subject,
   teacher as Teacher,
-} from "webuntis/resources";
+} from "../webuntis/resources/mod.ts";
 export * from "./Holiday.ts";
 export * from "./LoginStatus.ts";
 export * from "./Lesson.ts";


### PR DESCRIPTION
I didn't know that import maps were [meant to only be used by applications, not libraries](https://github.com/WICG/import-maps#scope), so using them here makes no sense.